### PR TITLE
chore(IDDEV-2): adding initial decision-record and README content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# org-decisions
-A repository for housing documented decisions, including process, approvers, commenters, and supercession, using the MADR format (even though the decision scope is broader than architecture).
+# Org-Wide Technical Decisions
+This repository documents organizational technical decisions across projects within the `IainDavis.dev` ecosystem.
+
+## Purpose
+These records exist to make our decision-making process transparent, traceable, and durable over time. They provide context for architectural, tooling, and process choices that impact multiple projects or define shared conventions.
+
+## Format
+We use the [MADR format](https://adr.github.io/madr/) (Markdown Architectural Decision Records) with light extensions:
+- Each decision is stored as a Markdown file under `decisions/`
+- Files are numbered and titled, e.g., `0001-title-of-decision.md`
+- Frontmatter includes fields like `status`, `date`, and `tags`
+
+## Usage
+- This content is published for reference and transparency.
+- Please do not reproduce or adapt these records without explicit permission.
+- If you have questions about a particular decision, feel free to reach out.
+
+## Status
+We are early in the process of collecting and formalizing these decisions. Expect this repository to evolve.
+
+---
+
+## Project-specific ADR collections
+Decisions specific to individual projects are stored within those projects, typically in a developer documentation branch.
+
+- [Docodylus ADRs][adrs-docodylus]
+
+<!-- NAMED LINKS -->
+[adrs-docodylus]:
+    https://github.com/IainDavis-dev/docodylus/tree/dev-docs/docs/adr
+    "Docodylus Architectural Decision Records"

--- a/decisions/000001-hosting-strategy-for-adr-repositories.md
+++ b/decisions/000001-hosting-strategy-for-adr-repositories.md
@@ -1,0 +1,67 @@
+---
+title: Hosting Strategy for ADR Repositories
+status: accepted
+date: 2025-06-10
+tags: [infra, process]
+---
+
+# 000001 - Hosting Strategy for ADR Repositories
+
+## Context
+
+As technical and organizational decisions grow in number and scope, it becomes important to manage where and how decisions are stored and surfaced. Our goals include:
+
+- Making decision records transparent and easily accessible
+- Supporting both org-wide and project-scoped decisions
+- Preserving the ability to evolve our tooling or presentation strategy over time
+- Minimizing initial setup effort while laying groundwork for future growth
+
+## Decision
+
+We will adopt the [MADR format](https://adr.github.io/madr/) with YAML frontmatter to capture metadata such as `title`, `status`, `date`, and `tags`. Decisions will be organized across two scopes:
+
+1. **Org-Wide Decisions**
+   - Stored in a public GitHub repository: `org-decisions`
+   - Located in a `decisions/` directory, with one file per decision
+   - Filenames will follow the pattern: six-digit, zero-padded, monotonically increasing integer, followed by a lowercased, hyphen-delimited version of the title (e.g., `000001-hosting-strategy-for-adr-repositories.md`)
+   - No dedicated viewer tooling initially—decisions will be read directly via GitHub
+   - No license applied, preserving full copyright
+
+2. **Project-Specific Decisions**
+   - Stored within each project repository
+   - Preferably in a developer documentation branch (e.g., `dev-docs`)
+   - If incompatible with documentation tooling, decisions may live in an orphan branch or a dedicated internal directory
+
+## Alternatives Considered
+
+- **Store decisions only in each project repo**  
+  *Rejected.* This would fragment high-level decisions and reduce visibility of org-wide choices (e.g., shared tooling or documentation standards).
+
+- **Single flat `adr/` directory in the org-wide repo**  
+  *Rejected.* Using a dedicated `decisions/` directory avoids future collision with tooling or index files.
+
+- **Render via MkDocs or Docusaurus immediately**  
+  *Postponed.* We opted to keep tooling light initially. Once a small library of decisions is established, we may revisit presentation options like:
+  - Docusaurus-based site
+  - `log4brains` viewer
+  - MkDocs with `awesome-pages-plugin`
+
+- **Use a permissive open-source license**  
+  *Rejected for now.* Given the personal and strategic nature of these decisions, we prefer to control reuse. This may change later.
+
+## Consequences
+
+### Positive
+
+- Avoids premature investment in viewer tooling while enabling future migration
+- Distinct scopes prevent cross-contamination of project-local vs. organizational decisions
+- GitHub provides a low-friction path to publish and consume decisions
+- YAML frontmatter enables machine-parsing and future viewer integration with minimal refactor
+
+### Negative
+
+- Markdown files viewed in GitHub may lack polish or structure expected from a documentation system
+- No index, search, or categorization beyond what GitHub provides natively
+- Requires manual navigation between related decisions (e.g., supersession)
+- Storing decisions in multiple locations introduces decentralization, increasing cognitive load for contributors who span multiple projects
+- Lacks built-in validation of metadata fields (e.g., typos in `status` or `tags`) unless future tooling is added


### PR DESCRIPTION
# [JIRA: IDDEV-2][jira-iddev2]

## Context
Immediate future work involves making and document decisions.

## Problem Statement
No current infrastructure exists for documenting decisions, either within the Docodylus project or in the wider IainDavis.dev org.

## Proposed Solution
Adopt and implement a decision-log policy for Docodylus and for IainDavis.dev

### In Scope for this PR
Decide on format, hosting, and presentation method for decision records within the broader IainDavis.dev domain. See [corresponding new ADR][adr-iaindavisdev-000001] for specific decisions made.

### Out of Scope for this PR
Decide on format, hosting, and presentation method for decision records within any project-specific domain.

<!-- NAMED LINKS -->
[jira-iddev2]: https://iaindavis.atlassian.net/browse/IDDEV-2 "Jira | IDDEV-2: Define and implement persistent ADR storage pattern"

[adr-iaindavisdev-000001]:
    https://github.com/IainDavis-dev/org-decisions/blob/e51014ea006a9be83415102be169071706f2ea8c/README.md
    "IainDavis.dev ADR 000001: Hosting Strategy for ADRs"