### PR TITLE
chore(no-ticket): add ADR specifying format for Jira-ticket estimate …

### DIFF
--- a/decisions/000002-standard-format-for-post-delivery-estimate-reflactions
+++ b/decisions/000002-standard-format-for-post-delivery-estimate-reflactions
@@ -1,0 +1,60 @@
+---
+title: Standard Format for Post-Delivery Estimate Reflections
+status: accepted
+date: 2025-06-10
+tags: [process, tracking]
+---
+
+# 000002 - Standard Format for Post-Delivery Estimate Reflections
+
+## Context
+
+As part of our ongoing practice improvement and estimation accuracy feedback, we’ve introduced a lightweight reflection process for completed issues. These reflections allow us to assess the quality of our point estimates, record observed deviations, and optionally recalibrate expectations for future planning.
+
+They also enable structured extraction of estimation trends over time, especially for solo or small-team environments where implicit retrospectives can go unrecorded.
+
+## Decision
+
+We will standardize a comment format—submitted by Nova—on all completed stories with meaningful execution effort. This format is designed for both human clarity and future machine parsing.
+
+The format includes fields for:
+- Original estimate
+- Actual time spent
+- Revised estimate (if re-pointed)
+- Explanation for discrepancies
+- Assessment of scope stability
+- Confidence score with brief rationale
+
+```text
+Post-Delivery Estimate Reflection (submitted by Nova):
+
+Story Points Assigned: [original estimate]
+Actual Time Spent: [duration or coarse-grain]
+Revised Estimate (if re-pointed): [updated point value]
+
+Reason for Deviation:
+[brief description of why actual effort differed from estimate]
+
+Scope Stability:
+[brief note on whether the scope changed during execution]
+
+Confidence in Original Estimate:
+[rating out of 5] — [optional one-line rationale]
+```
+
+## Alternatives Considered
+
+- **[FORMAT] Informal freeform notes**  
+  *Rejected.* Freeform writing is valuable for discovery but reduces consistency and makes analysis difficult.
+
+- **[FORMAT] Pure quantitative model (e.g., confidence = 80%)**  
+  *Rejected.* Over-quantifying confidence loses nuance and creates a false sense of precision.
+
+- **[AUTOMATION] Rely on velocity trends only**  
+  *Rejected.* Team velocity masks individual drift and doesn't highlight the why behind variances.
+
+## Consequences
+
+### Positive
+- Enables a lightweight form of estimation retro with negligible overhead
+- Provides structured


### PR DESCRIPTION
# [Jira IDDEV-7][jira-iddev7]

## Context
I've been looking for a way to capture variance between estimated effort and actual applied effort. Missing an estimation target produces very little actionable feedback, and there's no data collected to draw later inferences from. I can apply a quick-fix by doing a quick post-mortem per-issue with Nova, and capturing that as a comment on each Jira issue. Then later, we can do a retro with aggregated data per sprint, per quarter, etc. A standard format for this reflection better enables aggregation of the data and inference from those aggregations.

## Problem Statement
Define a standard format for post-effort estimation-variance reflections.

## Proposed Solution
This ADR captures a standard format for post-effort estimation-variance reflections. The same details have been captured in a ContextCard in Jira (project NOVAINT) for Nova's use when generating these reflections.

<!-- NAMED LINKS -->
[jira-iddev7]: https://iaindavis.atlassian.net/browse/IDDEV-7 "Jira | IDDEV-7: Capture standard for post-delivery estimate reflections as an ADR"